### PR TITLE
Sort streams by viewer count

### DIFF
--- a/util/streams.js
+++ b/util/streams.js
@@ -19,6 +19,7 @@ function fetchStreamsAndCreateSprites({
         fetchYoutubeStreams(youtubeQuery, youtubeKey, youtubeLimit)
     ])
         .then(([twitchStreams, youtubeStreams]) => twitchStreams.concat(youtubeStreams))
+        .then(allStreams => allStreams.sort((a, b) => b.viewers - a.viewers))
         .then(allStreams => allStreams.slice(0, limit))
         .then(allStreams => fetchStreamThumbnails(allStreams, thumbnailDir))
         .then(allStreams => createSpritesheet(allStreams, spritePath));

--- a/util/streams/twitch.js
+++ b/util/streams/twitch.js
@@ -20,7 +20,8 @@ function fetchTwitchStreams(game, clientId, limit = 10) {
                     status: stream.channel.status,
                     url: stream.channel.url,
                     thumbnail_src: stream.preview.medium,
-                    stream_src: "twitch"
+                    stream_src: "twitch",
+                    viewers: stream.viewers
                 };
             });
         });

--- a/util/streams/youtube.js
+++ b/util/streams/youtube.js
@@ -3,6 +3,7 @@ const fetch = require('node-fetch');
 const { buildUrl } = require('./utils');
 
 const YOUTUBE_GAME_STREAMS_URL = 'https://www.googleapis.com/youtube/v3/search?part=snippet&eventType=live&type=video';
+const YOUTUBE_LIVESTATS_URL = 'https://www.youtube.com/live_stats';
 
 function fetchYoutubeStreams(query, key, limit = 10) {
     var link = buildUrl(YOUTUBE_GAME_STREAMS_URL, {
@@ -16,13 +17,28 @@ function fetchYoutubeStreams(query, key, limit = 10) {
         .then(data => {
             return (data.items || []).map(item => {
                 return {
+                    videoId: item.id.videoId,
                     name: item.snippet.channelTitle,
                     status: item.snippet.title,
                     url: `https://www.youtube.com/watch?v=${item.id.videoId}`,
                     thumbnail_src: item.snippet.thumbnails.medium.url,
-                    stream_src: "youtube"
+                    stream_src: "youtube",
+                    viewers: 0
                 };
             });
+        })
+        .then(streams => Promise.all(streams.map(fetchYoutubeViewers)));
+}
+
+function fetchYoutubeViewers(stream) {
+    // viewer count is not available through youtube api v3 search
+    // have to request this information from livestats endpoint
+    var link = buildUrl(YOUTUBE_LIVESTATS_URL, { v: stream.videoId });
+    return fetch(link)
+        .then(res => res.json())
+        .then(viewers => {
+            stream.viewers = viewers;
+            return stream;
         });
 }
 


### PR DESCRIPTION
This sorts the streams by viewer count. YouTube required an extra endpoint to get this information.

I did implement sorting streams by date, however this was inefficient. It appears YouTube does not provide the livestream creation date, but instead gives the channel's creation date. I found streams that went live 15min ago with a reported creation date from 2015.

It's possible to get this information with another livestream endpoint, but I don't think it's worth it. Sorting by view count is enough.
